### PR TITLE
Enable scrollable review tables and extend heatmap

### DIFF
--- a/src/main/java/com/example/ctreview/controller/DashboardController.java
+++ b/src/main/java/com/example/ctreview/controller/DashboardController.java
@@ -62,14 +62,16 @@ public class DashboardController {
             graduations.add(new DashboardSummaryDto.DailyPoint(day.toString(), gradMap.getOrDefault(day, 0L)));
         }
 
-        // heatmap 소스: 최근 12주 = 84일(대략)
-        LocalDate heatFrom = today.minusDays(83);
-        var heatLogs = logRepo.findByActionDateBetween(heatFrom, today);
-        Map<LocalDate, Long> heatMap = heatLogs.stream()
+        // heatmap: 전체 기록
+        var allLogs = logRepo.findAll();
+        Map<LocalDate, Long> heatMap = allLogs.stream()
                 .collect(Collectors.groupingBy(ReviewLog::getActionDate, Collectors.counting()));
+        LocalDate heatFrom = allLogs.stream()
+                .map(ReviewLog::getActionDate)
+                .min(LocalDate::compareTo)
+                .orElse(today);
         List<DashboardSummaryDto.DailyPoint> heat = new ArrayList<>();
-        for (int i = 0; i <= 83; i++) {
-            LocalDate day = heatFrom.plusDays(i);
+        for (LocalDate day = heatFrom; !day.isAfter(today); day = day.plusDays(1)) {
             heat.add(new DashboardSummaryDto.DailyPoint(day.toString(), heatMap.getOrDefault(day, 0L)));
         }
 

--- a/src/main/java/com/example/ctreview/dto/DashboardSummaryDto.java
+++ b/src/main/java/com/example/ctreview/dto/DashboardSummaryDto.java
@@ -11,7 +11,7 @@ public record DashboardSummaryDto(
         List<DailyPoint> daily,              // 최근 30일 처리량
         Map<Integer, Long> levelDistribution,
         List<DailyPoint> graduations,        // 최근 30일 졸업 추이
-        List<DailyPoint> heatmap             // 히트맵 소스(최근 12주)
+        List<DailyPoint> heatmap             // 히트맵 소스(전체 기록)
 ) {
     @Builder
     public record DailyPoint(String date, long count) {}

--- a/src/main/resources/static/assets/app.css
+++ b/src/main/resources/static/assets/app.css
@@ -41,8 +41,8 @@ body {
 
 /* --- Header --- */
 header{ padding:16px 20px 8px 20px; max-width: 1280px; margin: 0 auto; }
-.header-row{ display:flex; align-items:flex-start; gap:16px; justify-content:space-between; }
-.header-left{ flex:1 1 auto; }
+.header-row{ display:flex; align-items:stretch; gap:16px; justify-content:space-between; }
+.header-left{ flex:1 1 auto; padding:16px; display:flex; flex-direction:column; }
 .header-left h1{ font-size: 22px; margin: 0 0 6px 0; }
 .sub { color: var(--muted); font-size: 13px; }
 .header-actions{ margin-top:8px; }
@@ -59,6 +59,8 @@ header{ padding:16px 20px 8px 20px; max-width: 1280px; margin: 0 auto; }
 .cell[data-level="3"] { background-color: var(--heat-3); }
 .cell[data-level="4"] { background-color: var(--heat-4); }
 
+.heatmap-legend{ display:flex; align-items:center; gap:4px; font-size:12px; color:var(--muted); margin-top:8px; }
+
 
 /* --- Container & Cards --- */
 .container{ max-width: 1280px; margin: 0 auto; }
@@ -72,7 +74,7 @@ header{ padding:16px 20px 8px 20px; max-width: 1280px; margin: 0 auto; }
 .card h2 { font-size: 16px; margin: 0; padding: 14px 16px; border-bottom: 1px solid var(--border); }
 .card .body { padding: 14px 16px; }
 .card--fixed{ display:flex; flex-direction:column; min-height:0; }
-.table-wrap{ flex:1 1 auto; min-height:0; overflow:hidden; border-radius:10px; }
+.table-wrap{ flex:1 1 auto; min-height:0; overflow:auto; border-radius:10px; }
 .card--clip{ display:flex; flex-direction:column; min-height:0; }
 .card--clip .body{ overflow:auto; }
 

--- a/src/main/resources/static/assets/app.js
+++ b/src/main/resources/static/assets/app.js
@@ -22,7 +22,6 @@ async function http(method, url, body) {
     return res.json();
 }
 const el = (id) => document.getElementById(id);
-function fmtStatus(s){ return s==='GRADUATED' ? `<span class="pill ok">졸업</span>` : `<span class="pill">${s}</span>`; }
 function fmtDate(d){ return d ?? '-'; }
 
 // ================== CORE LOGIC ==================
@@ -60,21 +59,6 @@ function toast(msg,type='info'){
     setTimeout(()=>div.remove(), 2200);
 }
 
-// ---- Pagination ----
-const PAGESIZE_TODAY = 10;
-const PAGESIZE_SEARCH = 15;
-let todayPage = 1, searchPage = 1;
-function paginate(tbody, page, pageSize, pageIndicatorId){
-    const rows = Array.from(tbody.querySelectorAll('tr'));
-    const total = Math.max(1, Math.ceil(rows.length / pageSize));
-    if(page > total) page = total;
-    rows.forEach((tr, idx)=>{ const p = Math.floor(idx / pageSize) + 1; tr.style.display = (p === page) ? '' : 'none'; });
-    el(pageIndicatorId).textContent = `${page} / ${total}`;
-    return page;
-}
-function renderTodayPage(){ todayPage = paginate(el('tbl-today'), todayPage, PAGESIZE_TODAY, 'today-page'); }
-function renderSearchPage(){ searchPage = paginate(el('tbl-search'), searchPage, PAGESIZE_SEARCH, 'search-page'); }
-
 // ---- Data Load & Render ----
 function createActionButtons(problem, type) {
     const tpl = el('row-actions');
@@ -109,7 +93,7 @@ async function loadToday(){
                     <td>${p.name}</td>
                     <td><code class="badge">LV.${p.currentLevel}</code></td>
                     <td>${p.reviewCount}</td>
-                    <td>${fmtStatus(p.status)}</td>
+                    <td>${fmtDate(p.nextReviewDate)}</td>
                     <td></td>`;
                 tr.children[6].appendChild(createActionButtons(p, 'today'));
                 tbody.appendChild(tr);
@@ -117,8 +101,6 @@ async function loadToday(){
         }
     } catch(e){
         tbody.innerHTML = `<tr><td colspan="7" style="color:var(--bad)">오늘 목록 로드 실패: ${e.message}</td></tr>`;
-    } finally {
-        renderTodayPage();
     }
 }
 
@@ -149,7 +131,7 @@ async function performSearch(){
                     <td>${p.name}</td>
                     <td><code class="badge">LV.${p.currentLevel}</code></td>
                     <td>${p.reviewCount}</td>
-                    <td>${fmtStatus(p.status)}</td>
+                    <td>${fmtDate(p.nextReviewDate)}</td>
                     <td></td>`;
                 tr.children[6].appendChild(createActionButtons(p, 'search')); // type: 'search' 전달
                 tbody.appendChild(tr);
@@ -157,8 +139,6 @@ async function performSearch(){
         }
     } catch(e){
         tbody.innerHTML = `<tr><td colspan="7" style="color:var(--bad)">검색 실패: ${e.message}</td></tr>`;
-    } finally {
-        renderSearchPage();
     }
 }
 
@@ -231,22 +211,36 @@ function renderWeeklyHeatmap(dailyCounts){
     const grid = el('heatmap-grid');
     if(!grid) return;
     grid.innerHTML='';
-    const map = new Map(); let maxVal = 0;
-    (dailyCounts||[]).forEach(({date,count})=>{ map.set(date,count); if(count>maxVal)maxVal=count; });
-    const today = new Date();
-    const start = new Date(today.setDate(today.getDate() - today.getDay() - 83));
 
-    for(let w=0;w<12;w++){ for(let d=0;d<7;d++){
-        const cellDate=new Date(start.getFullYear(),start.getMonth(),start.getDate()+(w*7+d));
-        const key = cellDate.toISOString().slice(0,10);
-        const val = map.get(key)??0;
-        const level = (val === 0) ? 0 : Math.min(4, Math.ceil(val / (Math.max(1, maxVal) / 4)));
-        const cell = document.createElement('div');
-        cell.className='cell';
-        cell.dataset.level = String(level);
-        cell.setAttribute('title',`${key}: ${val}`);
-        grid.appendChild(cell);
-    }}
+    const map = new Map();
+    let maxVal = 0;
+    (dailyCounts||[]).forEach(({date,count})=>{ map.set(date,count); if(count>maxVal)maxVal=count; });
+
+    const today = new Date();
+    const earliest = dailyCounts && dailyCounts.length ? new Date(dailyCounts[0].date) : today;
+    const diffDays = Math.floor((today - earliest) / (1000*60*60*24)) + 1;
+    const weeks = Math.max(12, Math.ceil(diffDays / 7));
+
+    const start = new Date(today);
+    start.setDate(start.getDate() - (weeks - 1) * 7);
+    start.setDate(start.getDate() - start.getDay());
+
+    for(let w=0; w<weeks; w++){
+        for(let d=0; d<7; d++){
+            const cellDate=new Date(start.getFullYear(),start.getMonth(),start.getDate()+(w*7+d));
+            const key = cellDate.toISOString().slice(0,10);
+            const val = map.get(key)??0;
+            const level = (val === 0) ? 0 : Math.min(4, Math.ceil(val / (Math.max(1, maxVal) / 4)));
+            const cell = document.createElement('div');
+            cell.className='cell';
+            cell.dataset.level = String(level);
+            cell.setAttribute('title',`${key}: ${val}`);
+            grid.appendChild(cell);
+        }
+    }
+
+    const wrapper = grid.parentElement;
+    if(wrapper) wrapper.scrollLeft = wrapper.scrollWidth;
 }
 
 async function loadDashboard(){
@@ -292,10 +286,6 @@ function init() {
     el('quick-solve')?.addEventListener('click', () => quickAction('solve'));
     el('quick-fail')?.addEventListener('click', () => quickAction('fail'));
     el('btn-refresh-dashboard')?.addEventListener('click', loadDashboard);
-    el('today-prev').addEventListener('click', ()=>{ todayPage = Math.max(1, todayPage-1); renderTodayPage(); });
-    el('today-next').addEventListener('click', ()=>{ todayPage++; renderTodayPage(); });
-    el('search-prev').addEventListener('click', ()=>{ searchPage = Math.max(1, searchPage-1); renderSearchPage(); });
-    el('search-next').addEventListener('click', ()=>{ searchPage++; renderSearchPage(); });
 
     // Date input UX
     ['s-from','s-to'].forEach(id=>{

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -10,8 +10,8 @@
         :root{
             /* 2. 카드 높이 기존 대비 1.5배 상향 조정 */
             --h-top: 500px;   /* 420px -> 630px */
-            --h-mid-1: 180px; /* 120px -> 180px */
-            --h-mid-2: 450px; /* 300px -> 450px */
+            --h-mid-1: 120px; /* 퀵리뷰 높이 조정 */
+            --h-mid-2: 510px; /* 검색/필터 영역 확대 */
         }
         .container{
             display:grid;
@@ -37,21 +37,28 @@
 <body>
 <header>
     <div class="header-row">
-        <div class="header-left">
+        <section class="card header-left">
             <h1>CTReview – 스마트 복습</h1>
             <div class="sub">Solve 전용 졸업, Fail 자동 연장(마지막 간격×2), 자동 이월, 검색/통계/히트맵 지원</div>
             <div class="header-actions">
                 <button class="btn" id="btn-theme">라이트 모드</button>
             </div>
-        </div>
+        </section>
         <section class="card heatmap-card header-right">
-            <h2>주간 히트맵 (최근 12주)</h2>
+            <h2>주간 히트맵</h2>
             <div class="body">
                 <div class="heatmap-wrapper">
                     <div class="heatmap-sidebar">
                         <div>월</div><div>화</div><div>수</div><div>목</div><div>금</div><div>토</div><div>일</div>
                     </div>
                     <div id="heatmap-grid" class="heatmap-grid" aria-label="weekly-heatmap"></div>
+                </div>
+                <div class="heatmap-legend" aria-label="heatmap-legend">
+                    <span class="cell" data-level="0"></span><span>없음</span>
+                    <span class="cell" data-level="1"></span>
+                    <span class="cell" data-level="2"></span>
+                    <span class="cell" data-level="3"></span>
+                    <span class="cell" data-level="4"></span><span>많음</span>
                 </div>
             </div>
         </section>
@@ -167,11 +174,6 @@
                     <tbody id="tbl-today"></tbody>
                 </table>
             </div>
-            <div class="row controls-bar" style="justify-content:flex-end; gap:6px;">
-                <button class="btn" id="today-prev">이전</button>
-                <code class="badge" id="today-page">1 / 1</code>
-                <button class="btn" id="today-next">다음</button>
-            </div>
         </div>
     </section>
 
@@ -192,11 +194,6 @@
                     </thead>
                     <tbody id="tbl-search"></tbody>
                 </table>
-            </div>
-            <div class="row controls-bar" style="justify-content:flex-end; gap:6px;">
-                <button class="btn" id="search-prev">이전</button>
-                <code class="badge" id="search-page">1 / 1</code>
-                <button class="btn" id="search-next">다음</button>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Render at least 12 weeks in weekly heatmap and auto-scroll to latest week
- Trim quick review height, enlarge search/filter panel, and restyle header
- Document that dashboard heatmap returns full history

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689af2a2b8c08326a5b0bdbad0cbff11