### PR TITLE
Fix grad list layout and move theme toggle

### DIFF
--- a/src/main/resources/static/assets/app.css
+++ b/src/main/resources/static/assets/app.css
@@ -25,20 +25,11 @@ header{ padding:16px 20px 8px 20px; max-width: 1280px; margin: 0 auto; }
 .header-row{ display:flex; align-items:stretch; gap:16px; }
 
 /* 🔽 이 부분을 수정하세요 🔽 */
-.header-left {
-    /* flex: 1 1 0; 를 아래 코드로 변경 */
-    flex: 0 0 calc(50% - 8px); /* 50% 너비에서 gap(16px)의 절반을 뺍니다 */
-}
-.header-center {
-    /* flex: 1 1 0; 를 아래 코드로 변경 */
-    flex: 1 1 auto; /* 남은 공간을 차지하도록 변경 */
-}
+.header-left { flex: 1 1 auto; }
 .header-right{ flex: 0 0 auto; }
-.header-center .card-body{ display:flex; justify-content:center; align-items:center; }
 
 .header-left .card-body { display: flex; flex-direction: column; height: 100%; }
 .header-left .sub { margin-top: 4px; }
-.header-left .header-actions{ margin-top: auto; } /* 테마 버튼을 하단으로 */
 
 /* --- 1. 월간 히트맵 스타일 --- */
 .heatmap-card .body { padding: 8px 12px;
@@ -150,6 +141,7 @@ tbody tr:hover td { background: rgba(255,255,255,0.02); }
 .row { display:flex; align-items:center; gap:8px; }
 canvas { width: 100%; height: auto; aspect-ratio: 640 / 260; background: #0b132a; border:1px solid #1b2445; border-radius: 10px; }
 .charts { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.charts > div { display:flex; flex-direction:column; min-width:0; }
 .footer-note { color: var(--muted); font-size: 12px; margin-top: 6px; }
 
 /*BADGES*/
@@ -169,6 +161,7 @@ code.badge {
 /* app.css 파일 하단에 추가 */
 
 .grad-list-container {
+    flex: 1 1 auto;
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -176,7 +169,6 @@ code.badge {
     background: #0b132a;
     border:1px solid #1b2445;
     border-radius: 10px;
-    height: 260px;
     width: 100%;
     overflow-y: auto;
     overflow-x: auto;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -42,15 +42,11 @@
                 <div class="sub">Solve 전용 졸업, Fail 자동 연장(마지막 간격×2), 자동 이월, 검색/통계/히트맵 지원</div>
                 <div id="auth-area" class="row" style="margin-top:8px; gap:8px;">
                     <span id="auth-user"></span>
+                    <button class="btn" id="btn-theme"><span id="theme-icon">🌙</span> <span id="theme-label">Dark</span></button>
                     <button class="btn" id="btn-login">로그인</button>
                     <button class="btn" id="btn-register">회원가입</button>
                     <button class="btn" id="btn-logout" style="display:none;">로그아웃</button>
                 </div>
-            </div>
-        </section>
-        <section class="card header-center">
-            <div class="card-body">
-                <button class="btn" id="btn-theme"><span id="theme-icon">🌙</span> <span id="theme-label">Dark</span></button>
             </div>
         </section>
         <section class="card heatmap-card header-right">


### PR DESCRIPTION
## Summary
- Prevent graduated problem list from stretching dashboard by enforcing flexible layout with scrolling
- Sync graduated list height with daily chart and keep theme/login controls on left header card

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching: {languageVersion=17})*


------
https://chatgpt.com/codex/tasks/task_e_689bfae4a5548326bcf5214634f1558e